### PR TITLE
Added unit tests agains current main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,25 @@
+name: Dockerized CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build docker images
+        run: docker compose build
+
+      - name: Run tests in backend container
+        run: docker compose run --rm backend npm test

--- a/README.md
+++ b/README.md
@@ -37,3 +37,8 @@ to create test users:
 `sh create_users.sh`
 
 if you go to localhost:8888/documentation you can see the API endpoints instead
+
+## Unit tests
+
+To run the unit tests:
+`docker-compose run --rm backend npm test`

--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ if you go to localhost:8888/documentation you can see the API endpoints instead
 
 ## Unit tests
 
-To run the unit tests:
+To run the unit tests:  
 `docker-compose run --rm backend npm test`

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,6 +7,10 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm install
 
+# Unit test dependencies
+RUN npm install --save-dev tap 
+RUN npm install --save-dev proxyquire
+
 COPY . .
 
 ENV SQLITE_DB_PATH=/data/database.sqlite

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server",
-    "dev": "nodemon server"
+    "dev": "nodemon server",
+    "test": "tap"
   },
   "keywords": [],
   "author": "",
@@ -18,7 +19,8 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
-    "nodemon": "^3.1.9"
+    "nodemon": "^3.1.9",
+    "tap": "^21.1.0"
   },
   "description": ""
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -17,19 +17,23 @@ fastify.register(import('@fastify/swagger-ui'), {
   transformSpecification: (swaggerObject, request, reply) => { return swaggerObject },
   transformSpecificationClone: true
 })
-
 fastify.register(require('./routes/users'))
+
+module.exports = fastify
 
 const PORT = 8888
 
 const start = async () => {
   try {
     await fastify.listen({ port: PORT, host: '0.0.0.0' })
+    /* c8 ignore start */
     console.log(`Server listening on http://localhost:${PORT}`)
+    /* c8 ignore stop */
   } catch (error) {
     fastify.log.error(error)
     process.exit(1)
   }
 }
-
-start()
+if (require.main == module) {
+	start()
+}

--- a/backend/test/db.test.js
+++ b/backend/test/db.test.js
@@ -1,0 +1,49 @@
+// ************************************************************************** //
+//                                                                            //
+//                                                        :::      ::::::::   //
+//   db.test.js                                         :+:      :+:    :+:   //
+//                                                    +:+ +:+         +:+     //
+//   By: jmakkone <jmakkone@student.hive.fi>        +#+  +:+       +#+        //
+//                                                +#+#+#+#+#+   +#+           //
+//   Created: 2025/04/03 01:00:10 by jmakkone          #+#    #+#             //
+//   Updated: 2025/04/03 01:00:19 by jmakkone         ###   ########.fr       //
+//                                                                            //
+// ************************************************************************** //
+
+const t = require('tap');
+const proxyquire = require('proxyquire');
+
+// Create a fake sqlite3 module that always calls the callback with an error.
+const fakeSqlite3 = {
+  verbose: () => ({
+    Database: function(path, callback) {
+      // Simulate an error opening the database.
+      callback(new Error("Simulated error"));
+    }
+  })
+};
+
+// Capture console.error so we can assert on its output.
+let capturedError = '';
+const originalConsoleError = console.error;
+console.error = (msg) => {
+  capturedError += msg;
+};
+
+t.test('db.js error handling: logs error when database fails to open', t => {
+  // Load the db module with sqlite3 replaced by our fake.
+  proxyquire('../db', {
+    'sqlite3': fakeSqlite3
+  });
+
+  // Check that our error message was printed.
+  t.match(
+    capturedError,
+    /Error opening database: Simulated error/i,
+    'Proper error message was logged'
+  );
+
+  // Restore console.error so other tests are not affected.
+  console.error = originalConsoleError;
+  t.end();
+});

--- a/backend/test/server-failcase.test.js
+++ b/backend/test/server-failcase.test.js
@@ -1,0 +1,51 @@
+// ************************************************************************** //
+//                                                                            //
+//                                                        :::      ::::::::   //
+//   server-failcase.test.js                            :+:      :+:    :+:   //
+//                                                    +:+ +:+         +:+     //
+//   By: jmakkone <jmakkone@student.hive.fi>        +#+  +:+       +#+        //
+//                                                +#+#+#+#+#+   +#+           //
+//   Created: 2025/04/03 01:56:01 by jmakkone          #+#    #+#             //
+//   Updated: 2025/04/03 02:20:25 by jmakkone         ###   ########.fr       //
+//                                                                            //
+// ************************************************************************** //
+
+const t = require('tap');
+const { spawn } = require('child_process');
+const net = require('net');
+
+t.test('server.js fails to bind port -> triggers catch block', t => {
+  // 1) Occupy port 8888 so the second server can’t bind
+  const dummyServer = net.createServer();
+  dummyServer.listen(8888, '127.0.0.1', () => {
+    // 2) Now spawn server.js in a child process
+    const child = spawn('node', ['server.js'], {
+      env: {
+        ...process.env,
+        // Override any DB path or other env if needed
+        SQLITE_DB_PATH: process.env.SQLITE_DB_PATH || ':memory:',
+      },
+      cwd: process.cwd()
+    });
+
+    let output = '';
+    child.stdout.on('data', data => {
+      output += data.toString();
+    });
+    child.stderr.on('data', data => {
+      output += data.toString();
+    });
+
+    child.on('exit', (code, signal) => {
+      t.equal(code, 1, 'child process should exit with code 1 on port bind failure');
+      t.match(output, /listen EADDRINUSE|fastify.log.error/, 'Error log or EADDRINUSE present');
+      dummyServer.close();  // release the port
+      t.end();
+    });
+  });
+
+  dummyServer.on('error', err => {
+    t.fail('Failed to occupy port 8888: ' + err.message);
+    t.end();
+  });
+});

--- a/backend/test/server.test.js
+++ b/backend/test/server.test.js
@@ -1,0 +1,70 @@
+// ************************************************************************** //
+//                                                                            //
+//                                                        :::      ::::::::   //
+//   server.test.js                                     :+:      :+:    :+:   //
+//                                                    +:+ +:+         +:+     //
+//   By: jmakkone <jmakkone@student.hive.fi>        +#+  +:+       +#+        //
+//                                                +#+#+#+#+#+   +#+           //
+//   Created: 2025/04/02 16:27:49 by jmakkone          #+#    #+#             //
+//   Updated: 2025/04/03 00:56:22 by jmakkone         ###   ########.fr       //
+//                                                                            //
+// ************************************************************************** //
+
+const t = require('tap');
+const fastify = require('../server');
+const db = require('../db');
+const { spawn } = require('child_process');
+
+// Test the Fastify instance initialization using fastify.ready()
+t.test('Server initializes correctly via fastify.ready()', t => {
+  fastify.ready(err => {
+    t.error(err, 'Server started without errors');
+    t.end();
+  });
+});
+
+// Test the code branch that calls start() when the module is run directly
+t.test('Server start() function runs when executed as main', t => {
+  const child = spawn('node', ['server.js'], {
+    env: {
+      ...process.env,
+      // Use an in-memory database for testing if not set
+      SQLITE_DB_PATH: process.env.SQLITE_DB_PATH || ':memory:',
+    }
+  });
+  
+  let output = '';
+  
+  child.stdout.on('data', data => {
+    output += data.toString();
+    if (output.includes(`Server listening on http://localhost:8888`)) {
+      t.match(
+        output,
+        /Server listening on http:\/\/localhost:8888/,
+        'Output contains the expected listening message'
+      );
+      // Send SIGINT to attempt a graceful shutdown.
+      child.kill('SIGINT');
+    }
+  });
+  
+  child.on('exit', (code, signal) => {
+    t.pass(`Child process exited with code ${code} and signal ${signal}`);
+    t.end();
+  });
+  
+  child.on('error', err => {
+    t.fail('Failed to spawn server.js: ' + err.message);
+    t.end();
+  });
+});
+
+// Teardown: Close resources so the process exits cleanly.
+t.teardown(async () => {
+  // Close the SQLite connection if still open.
+  await new Promise((resolve, reject) => {
+    db.close(err => (err ? reject(err) : resolve()));
+  });
+  // Close the Fastify instance.
+  await fastify.close();
+});

--- a/backend/test/swagger.test.js
+++ b/backend/test/swagger.test.js
@@ -1,0 +1,36 @@
+// ************************************************************************** //
+//                                                                            //
+//                                                        :::      ::::::::   //
+//   swagger.test.js                                    :+:      :+:    :+:   //
+//                                                    +:+ +:+         +:+     //
+//   By: jmakkone <jmakkone@student.hive.fi>        +#+  +:+       +#+        //
+//                                                +#+#+#+#+#+   +#+           //
+//   Created: 2025/04/02 16:28:39 by jmakkone          #+#    #+#             //
+//   Updated: 2025/04/03 01:44:44 by jmakkone         ###   ########.fr       //
+//                                                                            //
+// ************************************************************************** //
+
+const t = require('tap');
+const fastify = require('../server');
+
+t.test('GET /documentation returns Swagger docs', async t => {
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/documentation'
+  });
+
+  t.equal(response.statusCode, 200, 'Documentation endpoint should return status 200');
+  // Check that the payload contains a string like "Swagger" (case-insensitive)
+  t.match(response.payload, /swagger/i, 'Documentation page contains "swagger" text');
+});
+
+t.test('GET /documentation/json calls transformSpecification', async t => {
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/documentation/json'
+  });
+  t.equal(response.statusCode, 200, 'Should return 200 for the JSON spec');
+  
+  // The transformSpecification callback *should* have been invoked here,
+  // so if coverage was missing that function, this request will trigger it.
+});

--- a/backend/test/user-db-errors.test.js
+++ b/backend/test/user-db-errors.test.js
@@ -1,0 +1,83 @@
+// ************************************************************************** //
+//                                                                            //
+//                                                        :::      ::::::::   //
+//   user-db-errors.test.js                             :+:      :+:    :+:   //
+//                                                    +:+ +:+         +:+     //
+//   By: jmakkone <jmakkone@student.hive.fi>        +#+  +:+       +#+        //
+//                                                +#+#+#+#+#+   +#+           //
+//   Created: 2025/04/03 01:29:31 by jmakkone          #+#    #+#             //
+//   Updated: 2025/04/03 01:38:19 by jmakkone         ###   ########.fr       //
+//                                                                            //
+// ************************************************************************** //
+
+const t = require('tap');
+
+// 1) Mock the DB module
+// We'll create a simple fake object with stubbed methods.
+const dbMock = {
+  get: (sql, params, cb) => {
+    // Force an error no matter what the query is
+    cb(new Error('Simulated DB error'), null);
+  },
+  run: (sql, params, cb) => {
+    cb(new Error('Simulated DB error'));
+  },
+  all: (sql, params, cb) => {
+    cb(new Error('Simulated DB error'), null);
+  }
+};
+
+// 2) Load the server, telling Tap to replace '../db' with our mock
+//    This means every handler that does require('../db') will get dbMock instead.
+const fastify = t.mockRequire('../server', {
+  '../db': dbMock,
+});
+
+t.test('GET /users returns 500 when DB.all() errors', async t => {
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/users'
+  });
+  t.equal(response.statusCode, 500, 'Should return 500 on DB error');
+  const payload = JSON.parse(response.payload);
+  t.match(payload.error, /Database error/, 'Error message indicates DB failure');
+});
+
+t.test('GET /user/:id returns 500 when DB.get() errors', async t => {
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/user/999'
+  });
+  t.equal(response.statusCode, 500, 'Should return 500 on DB error');
+  const payload = JSON.parse(response.payload);
+  t.match(payload.error, /Database error/, 'Error message indicates DB failure');
+});
+
+t.test('PUT /user/:id returns 500 when DB.run() errors', async t => {
+  const response = await fastify.inject({
+    method: 'PUT',
+    url: '/user/999',
+    payload: { username: 'someuser' }
+  });
+  t.equal(response.statusCode, 500, 'Should return 500 on DB error');
+  const payload = JSON.parse(response.payload);
+  t.match(payload.error, /Database error/, 'Error message indicates DB failure');
+});
+
+t.test('POST /user/register returns 500 when DB.get() or DB.run() errors', async t => {
+  const response = await fastify.inject({
+    method: 'POST',
+    url: '/user/register',
+    payload: { username: 'bad', email: 'bad@example.com', password: 'bad' }
+  });
+  t.equal(response.statusCode, 500, 'Should return 500 on DB error');
+  const payload = JSON.parse(response.payload);
+  t.match(payload.error, /Database error/, 'Error message indicates DB failure');
+});
+
+// Since we're mocking the DB, we don't need to worry about clearing or
+// closing the real DB. But if your server is listening, you can still
+// close it in teardown:
+t.teardown(async () => {
+  await fastify.close();
+});

--- a/backend/test/user-db-insert-error.test.js
+++ b/backend/test/user-db-insert-error.test.js
@@ -1,0 +1,66 @@
+// ************************************************************************** //
+//                                                                            //
+//                                                        :::      ::::::::   //
+//   user-db-insert-error.test.js                       :+:      :+:    :+:   //
+//                                                    +:+ +:+         +:+     //
+//   By: jmakkone <jmakkone@student.hive.fi>        +#+  +:+       +#+        //
+//                                                +#+#+#+#+#+   +#+           //
+//   Created: 2025/04/03 01:33:35 by jmakkone          #+#    #+#             //
+//   Updated: 2025/04/03 01:38:02 by jmakkone         ###   ########.fr       //
+//                                                                            //
+// ************************************************************************** //
+
+const t = require('tap');
+
+// Mock the db module but only fail the INSERT
+const dbMock = {
+  // For the "SELECT * FROM users WHERE email = ?"
+  // we simulate "no user found" (null) and no error.
+  get: (sql, params, cb) => {
+    if (/SELECT \* FROM users/i.test(sql)) {
+      cb(null, null);
+    } else {
+      cb(new Error('Unexpected DB call in get()'));
+    }
+  },
+
+  // For the "INSERT INTO users (...)"
+  // we force an error to test the 'Error inserting user' branch.
+  run: (sql, params, cb) => {
+    if (/INSERT INTO users/i.test(sql)) {
+      cb(new Error('Simulated DB insert error'));
+    } else {
+      cb(new Error('Unexpected DB call in run()'));
+    }
+  },
+
+  // Not used by this route, but must exist if other parts of the code call them
+  all: (sql, params, cb) => cb(new Error('Unexpected DB call in all()'), null),
+};
+
+const fastify = t.mockRequire('../server', {
+  '../db': dbMock, // So the handlers see this mock instead of the real DB
+});
+
+t.test('POST /user/register -> fails on INSERT', async t => {
+  const response = await fastify.inject({
+    method: 'POST',
+    url: '/user/register',
+    payload: {
+      username: 'mockFail',
+      email: 'mockFail@example.com',
+      password: 'password'
+    }
+  });
+
+  t.equal(response.statusCode, 500, 'Should return 500 on INSERT error');
+  const payload = JSON.parse(response.payload);
+  t.match(payload.error, /Database error: Simulated DB insert error/i, 
+    'Error message indicates DB insert failure');
+
+  t.end();
+});
+
+t.teardown(async () => {
+  await fastify.close();
+});

--- a/backend/test/users.test.js
+++ b/backend/test/users.test.js
@@ -1,0 +1,168 @@
+// ************************************************************************** //
+//                                                                            //
+//                                                        :::      ::::::::   //
+//   users.test.js                                      :+:      :+:    :+:   //
+//                                                    +:+ +:+         +:+     //
+//   By: jmakkone <jmakkone@student.hive.fi>        +#+  +:+       +#+        //
+//                                                +#+#+#+#+#+   +#+           //
+//   Created: 2025/04/02 16:28:11 by jmakkone          #+#    #+#             //
+//   Updated: 2025/04/03 00:45:57 by jmakkone         ###   ########.fr       //
+//                                                                            //
+// ************************************************************************** //
+
+const t = require('tap');
+const fastify = require('../server');
+const db = require('../db');
+
+let registeredUserId;
+
+// --- Positive Flow: Register, get, update, and list a user ---
+t.test('Positive User Flow', async t => {
+  t.test('POST /user/register registers a new user', async t => {
+    const newUser = {
+      username: 'testuser',
+      email: 'testuser@example.com',
+      password: 'secret'
+    };
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/user/register',
+      payload: newUser
+    });
+
+    t.equal(response.statusCode, 200, 'Registration returns status code 200');
+    const payload = JSON.parse(response.payload);
+    t.ok(payload.id, 'Response includes an id');
+    t.equal(payload.username, newUser.username, 'Username matches');
+    registeredUserId = payload.id;
+  });
+
+  t.test('GET /user/:id returns the registered user', async t => {
+    t.ok(registeredUserId, 'User id is set from registration');
+    const response = await fastify.inject({
+      method: 'GET',
+      url: `/user/${registeredUserId}`
+    });
+    t.equal(response.statusCode, 200, 'GET user returns status 200');
+    const payload = JSON.parse(response.payload);
+    t.equal(payload.id, Number(registeredUserId), 'Returned id matches');
+  });
+
+  t.test('PUT /user/:id updates the user', async t => {
+    t.ok(registeredUserId, 'User id is set');
+    const updatedData = { username: 'updateduser' };
+
+    const response = await fastify.inject({
+      method: 'PUT',
+      url: `/user/${registeredUserId}`,
+      payload: updatedData
+    });
+    t.equal(response.statusCode, 200, 'PUT update returns status 200');
+    const payload = JSON.parse(response.payload);
+    t.equal(payload.username, updatedData.username, 'Username is updated');
+  });
+
+  t.test('GET /users returns a list including the user', async t => {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/users'
+    });
+    t.equal(response.statusCode, 200, 'GET /users returns status 200');
+    const payload = JSON.parse(response.payload);
+    t.ok(Array.isArray(payload), 'Response is an array');
+    const user = payload.find(u => u.id === Number(registeredUserId));
+    t.ok(user, 'The registered (and updated) user is in the list');
+  });
+});
+
+// --- Negative Flow: Test error cases ---
+t.test('Negative User Flow', async t => {
+  // First, clear the users table so that tests run from a known state.
+  await new Promise((resolve, reject) => {
+    db.run('DELETE FROM users', err => err ? reject(err) : resolve());
+  });
+
+  t.test('POST /user/register returns 400 for duplicate email', async t => {
+    const newUser = {
+      username: 'dupuser',
+      email: 'dup@example.com',
+      password: 'secret'
+    };
+
+    // First registration should succeed.
+    const response1 = await fastify.inject({
+      method: 'POST',
+      url: '/user/register',
+      payload: newUser
+    });
+    t.equal(response1.statusCode, 200, 'First registration succeeds');
+
+    // Duplicate registration should fail.
+    const response2 = await fastify.inject({
+      method: 'POST',
+      url: '/user/register',
+      payload: newUser
+    });
+    t.equal(response2.statusCode, 400, 'Duplicate registration returns 400');
+    const payload2 = JSON.parse(response2.payload);
+    t.match(payload2.error, /already exists/i, 'Error indicates duplicate email');
+  });
+
+  t.test('GET /user/:id returns 404 for non-existent user', async t => {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/user/9999'
+    });
+    t.equal(response.statusCode, 404, 'GET on non-existent user returns 404');
+    const payload = JSON.parse(response.payload);
+    t.match(payload.error, /not found/i, 'Error message indicates user not found');
+  });
+
+  t.test('PUT /user/:id returns 404 when updating non-existent user', async t => {
+    const response = await fastify.inject({
+      method: 'PUT',
+      url: '/user/9999',
+      payload: { username: 'doesnotexist' }
+    });
+    t.equal(response.statusCode, 404, 'PUT on non-existent user returns 404');
+    const payload = JSON.parse(response.payload);
+    t.match(payload.error, /not found/i, 'Error message indicates user not found');
+  });
+
+  t.test('GET /users returns 404 when no users exist', async t => {
+    // Clear the table again.
+    await new Promise((resolve, reject) => {
+      db.run('DELETE FROM users', err => err ? reject(err) : resolve());
+    });
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/users'
+    });
+    t.equal(response.statusCode, 404, 'GET /users returns 404 when table is empty');
+    const payload = JSON.parse(response.payload);
+    t.match(payload.error, /No users found/i, 'Error message indicates no users found');
+  });
+});
+
+// --- Teardown: Clean up and close resources ---
+t.teardown(async () => {
+  try {
+    // Ensure the users table is cleared.
+    await new Promise((resolve, reject) => {
+      db.run('DELETE FROM users', err => err ? reject(err) : resolve());
+    });
+    // Close the SQLite connection.
+    await new Promise((resolve, reject) => {
+      db.close((err) => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
+    // Close the Fastify instance.
+    await fastify.close();
+  } catch (err) {
+    console.error('Teardown error:', err);
+    throw err;
+  }
+});


### PR DESCRIPTION
Included github workflow file to automate the testing for pull and push requests.

Unit tests are using [tap](https://github.com/tapjs/tapjs)  as a test framework.

Tap seems to be pretty precise in the app code base testing, it requires you to test every possible branch, function and code snippet from the code that gets added.

This will multiply the amount of code that needs to be written as tests, so this might be a case for a discussion. For example we could lower or modify the test coverage. For a small hard to test code snippets you can add guiding comments for tap to skip them in testing phase:
`    /* c8 ignore start */
    console.log(`Server listening on http://localhost:${PORT}`)
    /* c8 ignore stop */
`
or if you want to check does the tests fails because of not fully covering whole code base:
`docker-compose run --rm backend npm test  -- --allow-incomplete-coverage`

Now there's tests for currently implemented features, it passes the local manual tests and workflow automated tests. I relied on chatgpts help to generate test snippets for the current endpoints.